### PR TITLE
自己対戦フレームワーク関連の微修正

### DIFF
--- a/source/engine/local-game-server/local-game-server.cpp
+++ b/source/engine/local-game-server/local-game-server.cpp
@@ -608,27 +608,42 @@ void Thread::search()
     {
       draw++;
 #ifdef ONE_LINE_OUTPUT_MODE
-      sync_cout << "draw," << rootPos.sfen() << sync_endl;
+      sync_cout << (player1_color == Color::BLACK ? "black-" : "white-")
+              << "draw," << rootPos.sfen() << sync_endl;
 #else
-      cout << '.'; // 引き分けマーク
+      if (player1_color == Color::BLACK) {
+        cout << '*'; // 先手で引き分けマーク
+      } else {
+        cout << '.'; // 後手で引き分けマーク
+      }
 #endif
     }
     else if (rootPos.side_to_move() == player1_color)
     {
       lose++;
 #ifdef ONE_LINE_OUTPUT_MODE
-      sync_cout << "lose," << rootPos.sfen() << sync_endl;
+      sync_cout << (player1_color == Color::BLACK ? "black-" : "white-")
+              << "lose," << rootPos.sfen() << sync_endl;
 #else
-      cout << 'X'; // 負けマーク
+      if (player1_color == Color::BLACK) {
+        cout << 'X'; // 先手で負けマーク
+      } else {
+        cout << 'x'; // 後手で負けマーク
+      }
 #endif
     }
     else
     {
       win++;
 #ifdef ONE_LINE_OUTPUT_MODE
-      sync_cout << "win," << rootPos.sfen() << sync_endl;
+      sync_cout << (player1_color == Color::BLACK ? "black-" : "white-")
+              << "win," << rootPos.sfen() << sync_endl;
 #else
-      cout << 'O'; // 勝ちマーク
+      if (player1_color == Color::BLACK) {
+        cout << 'O'; // 先手で勝ちマーク
+      } else {
+        cout << 'o'; // 後手で勝ちマーク
+      }
 #endif
     }
     player1_color = get_next_player1_color_unlocked(); // 先後入れ替える。

--- a/source/engine/local-game-server/local-game-server.cpp
+++ b/source/engine/local-game-server/local-game-server.cpp
@@ -638,7 +638,9 @@ void Thread::search()
     es[0].game_over();
     es[1].game_over();
     games++;
+#ifdef ONE_LINE_OUTPUT_MODE
     std::cerr << '.';
+#endif
   };
 
   string line;

--- a/source/engine/local-game-server/local-game-server.cpp
+++ b/source/engine/local-game-server/local-game-server.cpp
@@ -529,7 +529,7 @@ void MainThread::think() {
   Thread::search();
   for (auto th : Threads.slaves) th->wait_for_search_finished();
 
-  sync_cout << endl << "local game server end : [" << engine_name[0] << "] vs [" << engine_name[1] << "]" << sync_endl;
+  sync_cout << endl << "local game server end : [" << engine_name[0] << "(" << usi_engine_name[0] << ")] vs [" << engine_name[1] << "(" << usi_engine_name[1] << ")]" << sync_endl;
   sync_cout << "GameResult " << win << " - " << draw << " - " << lose << sync_endl;
 
 #ifdef ONE_LINE_OUTPUT_MODE


### PR DESCRIPTION
コミットログの通りですが、自己対戦フレームワーク使用時の使い勝手を向上しました。
先手後手の管理を統一して、少ないbtimeでもengine1が先手に偏ってしまいにくいようにしました。
ログ表示方法も少し変えてしまっているので、邪魔そうだったらリジェクトして下さい。